### PR TITLE
Programatic retrieval of oscal components

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -67,12 +67,8 @@ type BigBangValues struct {
 	} `yaml:"networkPolicies"`
 	ImagePullPolicy string `yaml:"imagePullPolicy"`
 	Istio           struct {
-		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
+		Enabled         bool `yaml:"enabled"`
+		Git             Git  `yaml:"git"`
 		Enterprise      bool `yaml:"enterprise"`
 		IngressGateways struct {
 			PublicIngressgateway struct {
@@ -102,12 +98,8 @@ type BigBangValues struct {
 	} `yaml:"istio"`
 	Istiooperator struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
@@ -115,12 +107,8 @@ type BigBangValues struct {
 	} `yaml:"istiooperator"`
 	Jaeger struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 			Install struct {
 				Crds string `yaml:"crds"`
 			} `yaml:"install"`
@@ -142,12 +130,8 @@ type BigBangValues struct {
 	} `yaml:"jaeger"`
 	Kiali struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Ingress struct {
 			Gateway string `yaml:"gateway"`
@@ -163,12 +147,8 @@ type BigBangValues struct {
 	} `yaml:"kiali"`
 	ClusterAuditor struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
@@ -176,12 +156,8 @@ type BigBangValues struct {
 	} `yaml:"clusterAuditor"`
 	Gatekeeper struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 			Install struct {
 				Crds string `yaml:"crds"`
 			} `yaml:"install"`
@@ -195,12 +171,8 @@ type BigBangValues struct {
 	} `yaml:"gatekeeper"`
 	Kyverno struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
@@ -208,12 +180,8 @@ type BigBangValues struct {
 	} `yaml:"kyverno"`
 	Kyvernopolicies struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
@@ -221,12 +189,8 @@ type BigBangValues struct {
 	} `yaml:"kyvernopolicies"`
 	Logging struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 			Timeout string `yaml:"timeout"`
 		} `yaml:"flux"`
 		Ingress struct {
@@ -247,24 +211,16 @@ type BigBangValues struct {
 	} `yaml:"logging"`
 	Eckoperator struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
 	} `yaml:"eckoperator"`
 	Fluentbit struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
@@ -272,12 +228,8 @@ type BigBangValues struct {
 	} `yaml:"fluentbit"`
 	Promtail struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Values struct {
 		} `yaml:"values"`
@@ -298,11 +250,7 @@ type BigBangValues struct {
 	} `yaml:"loki"`
 	Tempo struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
+		Git     Git  `yaml:"git"`
 		Ingress struct {
 			Gateway string `yaml:"gateway"`
 		} `yaml:"ingress"`
@@ -314,12 +262,8 @@ type BigBangValues struct {
 	} `yaml:"tempo"`
 	Monitoring struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 			Install struct {
 				Crds string `yaml:"crds"`
 			} `yaml:"install"`
@@ -354,12 +298,8 @@ type BigBangValues struct {
 	} `yaml:"monitoring"`
 	Twistlock struct {
 		Enabled bool `yaml:"enabled"`
-		Git     struct {
-			Repo string `yaml:"repo"`
-			Path string `yaml:"path"`
-			Tag  string `yaml:"tag"`
-		} `yaml:"git"`
-		Flux struct {
+		Git     Git  `yaml:"git"`
+		Flux    struct {
 		} `yaml:"flux"`
 		Ingress struct {
 			Gateway string `yaml:"gateway"`
@@ -371,12 +311,8 @@ type BigBangValues struct {
 	Addons struct {
 		Argocd struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Ingress struct {
 				Gateway string `yaml:"gateway"`
@@ -398,12 +334,8 @@ type BigBangValues struct {
 		} `yaml:"argocd"`
 		Authservice struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Values struct {
 			} `yaml:"values"`
@@ -413,12 +345,8 @@ type BigBangValues struct {
 		} `yaml:"authservice"`
 		MinioOperator struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Values struct {
 			} `yaml:"values"`
@@ -426,12 +354,8 @@ type BigBangValues struct {
 		} `yaml:"minioOperator"`
 		Minio struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Ingress struct {
 				Gateway string `yaml:"gateway"`
@@ -493,24 +417,16 @@ type BigBangValues struct {
 		} `yaml:"gitlab"`
 		GitlabRunner struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Values struct {
 			} `yaml:"values"`
 			PostRenderers []interface{} `yaml:"postRenderers"`
 		} `yaml:"gitlabRunner"`
 		Nexus struct {
-			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
+			Enabled    bool   `yaml:"enabled"`
+			Git        Git    `yaml:"git"`
 			LicenseKey string `yaml:"license_key"`
 			Ingress    struct {
 				Gateway string `yaml:"gateway"`
@@ -542,12 +458,8 @@ type BigBangValues struct {
 		} `yaml:"nexus"`
 		Sonarqube struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Ingress struct {
 				Gateway string `yaml:"gateway"`
@@ -590,12 +502,8 @@ type BigBangValues struct {
 		} `yaml:"haproxy"`
 		Anchore struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 				Upgrade struct {
 					DisableWait bool `yaml:"disableWait"`
 				} `yaml:"upgrade"`
@@ -633,12 +541,8 @@ type BigBangValues struct {
 		} `yaml:"anchore"`
 		Mattermostoperator struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Values struct {
 			} `yaml:"values"`
@@ -646,12 +550,8 @@ type BigBangValues struct {
 		} `yaml:"mattermostoperator"`
 		Mattermost struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Enterprise struct {
 				Enabled bool   `yaml:"enabled"`
@@ -691,12 +591,8 @@ type BigBangValues struct {
 		} `yaml:"mattermost"`
 		Velero struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Plugins []interface{} `yaml:"plugins"`
 			Values  struct {
@@ -704,12 +600,8 @@ type BigBangValues struct {
 			PostRenderers []interface{} `yaml:"postRenderers"`
 		} `yaml:"velero"`
 		Keycloak struct {
-			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
+			Enabled  bool `yaml:"enabled"`
+			Git      Git  `yaml:"git"`
 			Database struct {
 				Host     string `yaml:"host"`
 				Type     string `yaml:"type"`
@@ -730,12 +622,8 @@ type BigBangValues struct {
 		} `yaml:"keycloak"`
 		Vault struct {
 			Enabled bool `yaml:"enabled"`
-			Git     struct {
-				Repo string `yaml:"repo"`
-				Path string `yaml:"path"`
-				Tag  string `yaml:"tag"`
-			} `yaml:"git"`
-			Flux struct {
+			Git     Git  `yaml:"git"`
+			Flux    struct {
 			} `yaml:"flux"`
 			Ingress struct {
 				Gateway string `yaml:"gateway"`
@@ -745,6 +633,12 @@ type BigBangValues struct {
 			PostRenderers []interface{} `yaml:"postRenderers"`
 		} `yaml:"vault"`
 	} `yaml:"addons"`
+}
+
+type Git struct {
+	Repo string `yaml:"repo"`
+	Path string `yaml:"path,omitempty"`
+	Tag  string `yaml:"tag,omitempty"`
 }
 
 type OscalComponentDocument struct {

--- a/internal/utils/git-extractor.go
+++ b/internal/utils/git-extractor.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/defenseunicorns/bigbang-oscal-component-generator/internal/types"
+)
+
+// Extract git objects from bigbang values
+func ExtractGit(valuesStruct interface{}) []types.Git {
+
+	var gits []types.Git
+	var addons interface{}
+	v := reflect.ValueOf(valuesStruct)
+	n := reflect.TypeOf(valuesStruct)
+	values := make([]interface{}, v.NumField())
+
+	for i := range values {
+		reflectValue := v.Field(i)
+		name := n.Field(i).Name
+		// Recurse on nested addons
+		if name == "Addons" {
+			addons = reflectValue.Interface()
+			gits = append(gits, ExtractGit(addons)...)
+		}
+		gits = addValidatedGitToSlice(gits, reflectValue)
+	}
+	return gits
+}
+
+// Adds git to slice if its able to extract from reflected value.
+func addValidatedGitToSlice(gits []types.Git, reflectValue reflect.Value) []types.Git {
+	if reflectValue.Kind() == reflect.Struct {
+		git, ok := convertReflectToGit(reflectValue)
+		if ok {
+			gits = append(gits, git)
+		}
+	}
+	return gits
+}
+
+// Retrieves the Git struct from a value in BigBang Chart if it exists.
+func convertReflectToGit(reflectValue reflect.Value) (types.Git, bool) {
+	reflectValueInterface := reflectValue.Interface()
+	// Types and Name
+	subTypes := reflect.TypeOf(reflectValueInterface)
+	// Reflect Value
+	subValues := reflect.ValueOf(reflectValueInterface)
+	// Validate git field exists
+	fbn, ok := subTypes.FieldByName("Git")
+	if ok {
+		subVal := subValues.FieldByName(fbn.Name)
+		gitInterface := subVal.Interface()
+		// Try to cast
+		gitStruct, ok := gitInterface.(types.Git)
+		// Validate cast successful and return types.Git struct
+		if ok {
+			return gitStruct, true
+		}
+	}
+	// Fall through failure case.
+	return types.Git{}, false
+}
+
+func ExtractTest() {
+	x := struct {
+		Foo string
+		Bar int
+	}{"foo", 2}
+
+	v := reflect.ValueOf(x)
+
+	values := make([]interface{}, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		values[i] = v.Field(i).Interface()
+	}
+
+	fmt.Println(values)
+}

--- a/internal/utils/network.go
+++ b/internal/utils/network.go
@@ -1,4 +1,4 @@
-package network
+package utils
 
 import (
 	"fmt"

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/defenseunicorns/bigbang-oscal-component-generator/internal/types"
-	network "github.com/defenseunicorns/bigbang-oscal-component-generator/internal/utils"
+	"github.com/defenseunicorns/bigbang-oscal-component-generator/internal/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -38,149 +38,26 @@ func getAllOscalComponents() ([]types.OscalComponent, error) {
 
 func getAllOscalComponentDocuments() ([]types.OscalComponentDocument, error) {
 	var components []types.OscalComponentDocument
-	bigBangValues, err := getBigBangValuesYaml()
+	bigBangValues, err := GetBigBangValuesYaml()
 	if err != nil {
 		return nil, err
 	}
-	// Core
-	component, err := getOscalComponentYaml(bigBangValues.Istio.Git.Repo, bigBangValues.Istio.Git.Tag)
-	if err == nil {
+	gits := utils.ExtractGit(bigBangValues)
+	for _, git := range gits {
+		component, _ := getOscalComponentYaml(git.Repo, git.Tag)
 		components = append(components, component)
 	}
-	component, err = getOscalComponentYaml(bigBangValues.Istiooperator.Git.Repo, bigBangValues.Istiooperator.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Jaeger.Git.Repo, bigBangValues.Jaeger.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Kiali.Git.Repo, bigBangValues.Kiali.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.ClusterAuditor.Git.Repo, bigBangValues.ClusterAuditor.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Gatekeeper.Git.Repo, bigBangValues.Gatekeeper.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Kyverno.Git.Repo, bigBangValues.Kyverno.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Kyvernopolicies.Git.Repo, bigBangValues.Kyvernopolicies.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Logging.Git.Repo, bigBangValues.Logging.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Eckoperator.Git.Repo, bigBangValues.Eckoperator.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Fluentbit.Git.Repo, bigBangValues.Fluentbit.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Promtail.Git.Repo, bigBangValues.Promtail.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Loki.Git.Repo, bigBangValues.Loki.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Tempo.Git.Repo, bigBangValues.Tempo.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Monitoring.Git.Repo, bigBangValues.Monitoring.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Twistlock.Git.Repo, bigBangValues.Twistlock.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-
-	// Addons
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Argocd.Git.Repo, bigBangValues.Addons.Argocd.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Authservice.Git.Repo, bigBangValues.Addons.Authservice.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.MinioOperator.Git.Repo, bigBangValues.Addons.MinioOperator.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Minio.Git.Repo, bigBangValues.Addons.Minio.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Gitlab.Git.Repo, bigBangValues.Addons.Gitlab.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.GitlabRunner.Git.Repo, bigBangValues.Addons.GitlabRunner.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Nexus.Git.Repo, bigBangValues.Addons.Nexus.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Sonarqube.Git.Repo, bigBangValues.Addons.Sonarqube.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Haproxy.Git.Repo, bigBangValues.Addons.Haproxy.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Anchore.Git.Repo, bigBangValues.Addons.Anchore.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Mattermostoperator.Git.Repo, bigBangValues.Addons.Mattermostoperator.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Mattermost.Git.Repo, bigBangValues.Addons.Mattermost.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Velero.Git.Repo, bigBangValues.Addons.Velero.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Keycloak.Git.Repo, bigBangValues.Addons.Keycloak.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-	component, err = getOscalComponentYaml(bigBangValues.Addons.Vault.Git.Repo, bigBangValues.Addons.Vault.Git.Tag)
-	if err == nil {
-		components = append(components, component)
-	}
-
 	return components, nil
 }
 
-func getBigBangValuesYaml() (types.BigBangValues, error) {
+func GetBigBangValuesYaml() (types.BigBangValues, error) {
 	var bbValues types.BigBangValues
 	fileUrl := "https://repo1.dso.mil/platform-one/big-bang/bigbang/-/raw/master/chart/values.yaml"
 	uri, err := url.Parse(fileUrl)
 	if err != nil {
 		return bbValues, fmt.Errorf("invalid URL pattern %v", err)
 	}
-	bytes, err := network.FetchFromHTTPResource(uri)
+	bytes, err := utils.FetchFromHTTPResource(uri)
 	if err != nil {
 		return bbValues, err
 	}
@@ -196,7 +73,7 @@ func getOscalComponentYaml(repo string, tag string) (types.OscalComponentDocumen
 	if err != nil {
 		return component, err
 	}
-	bytes, err := network.FetchFromHTTPResource(uri)
+	bytes, err := utils.FetchFromHTTPResource(uri)
 	if err != nil {
 		return component, err
 	}


### PR DESCRIPTION
Created git-extractor to pull the Git type out of components and addons of a provided interface in order to programmatically retrieve the oscal component yamls from their repos.